### PR TITLE
Added support for a delivery address of 'dev' 

### DIFF
--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,5 +1,5 @@
 import { useImageEngineContext } from "../context"
-import { constructUrl, generateSrcSetString } from "../utils"
+import { constructUrl, generateSrcSetString, buildUrlFromDeliveryAddress } from "../utils"
 
 const ALLOWED_INPUT_EXTENSIONS = [
   "png",
@@ -42,8 +42,9 @@ export type TDirectives = {
     | "mp4"
     | "jxr"
     | "avif"
+    | ""
   // Define desired fit method.
-  fitMethod?: "stretch" | "box" | "letterbox" | "cropbox"
+  fitMethod?: "stretch" | "box" | "letterbox" | "cropbox" | ""
   // Don't apply any optimizations to the origin image.
   noOptimization?: true
   // Adjust sharpness.
@@ -77,7 +78,7 @@ export function Image(props: TProps): JSX.Element {
   }
 
   const { deliveryAddress } = useImageEngineContext()
-  const imageUrl = deliveryAddress + src
+  const imageUrl = buildUrlFromDeliveryAddress(deliveryAddress, src);
   const [imageExtension] = src.split(".").slice(-1)
 
   if (!ALLOWED_INPUT_EXTENSIONS.includes(imageExtension)) {
@@ -92,7 +93,7 @@ export function Image(props: TProps): JSX.Element {
       src={
         directives ? constructUrl(imageUrl, directives) : imageUrl
       }
-      srcSet={srcSet && generateSrcSetString(srcSet, deliveryAddress)}
+      srcSet={srcSet && generateSrcSetString(srcSet, deliveryAddress, imageUrl)}
       {...other}
     />
   )

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -7,7 +7,7 @@ const ALLOWED_INPUT_EXTENSIONS = [
   "jpg",
   "bmp",
   "webp",
-  "jpeg2000",
+  "jp2",
   "svg",
   "tif",
 ]
@@ -37,7 +37,7 @@ export type TDirectives = {
     | "jpg"
     | "bmp"
     | "webp"
-    | "jpeg2000"
+    | "jp2"
     | "svg"
     | "mp4"
     | "jxr"

--- a/src/components/Source.tsx
+++ b/src/components/Source.tsx
@@ -7,11 +7,11 @@ export type TProps = Omit<JSX.IntrinsicElements["source"], "srcSet"> & {
 }
 
 export function Source (props: TProps): JSX.Element {
-  const { srcSet, ...other } = props
+  const { srcSet, src, ...other } = props
 
   const { deliveryAddress } = useImageEngineContext()
   
   return (
-    <source srcSet={generateSrcSetString(srcSet, deliveryAddress)} {...other} />
+    <source srcSet={generateSrcSetString(srcSet, deliveryAddress, src)} {...other} />
   )
 }

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -16,38 +16,61 @@ const DIRECTIVE_MAPPING: { [key: string]: string } = {
   keepMeta: "meta",
 }
 
+const DEV_ADDRESS: string = "dev";
+
 export function constructUrl(src: string, directives: TDirectives): string {
-  const params = Object.entries(directives).reduce((result, [key, value]) => {
-    if (DIRECTIVE_MAPPING[key]) {
-      return result + `/${DIRECTIVE_MAPPING[key]}_${value}`
+    const params = Object.entries(directives).reduce((result, [key, value]) => {
+	if (value === null || value === undefined || value === "") {
+	    return result;
+	    
+	} else if (DIRECTIVE_MAPPING[key]) {
+	    return result + `/${DIRECTIVE_MAPPING[key]}_${value}`
+	}
+
+	console.warn(`Directive '${key}' isn't recognized and won't be applied to the image.`);
+	
+	return result
+    }, "");
+
+    return params ? `${src}?imgeng=${params}` : src;
+};
+
+export function generateSrcSetString(srcSet: TSrcSet, deliveryAddress: string, originalUrl?: string): string {
+    return srcSet.reduce((result, { src, width, directives }) => {
+	// Extract width directive and always apply it to the image as
+	// its size has to match provided width descriptor.
+	const widthDirective = {
+	    width: Number(width.replace("w", "")),
+	}
+
+	let fullAddress : string;
+
+	// If the delivery address is "dev" set the fullAddress to originalUrl
+	// Otherwise set it to deliveryAddress + the srcSet src
+	if (deliveryAddress === DEV_ADDRESS && originalUrl) {
+	    fullAddress = originalUrl;
+	} else {
+	    fullAddress = deliveryAddress + src;
+	}
+	
+	const fullImageUrl = constructUrl(
+	    fullAddress,
+	    directives
+		? {
+		    ...directives,
+		    ...widthDirective,
+		}
+	    : widthDirective
+	)
+	const entry = `${fullImageUrl} ${width},\n`
+	return result += entry
+    }, "");
+};
+
+export function buildUrlFromDeliveryAddress(deliveryAddress: string, src: string): string {
+    if (deliveryAddress === DEV_ADDRESS) {
+	return src;
+    } else {
+	return deliveryAddress +  src;
     }
-
-    console.warn(
-      `Directive '${key}' isn't recognized and won't be applied to the image.`
-    )
-    return result
-  }, "")
-
-  return `${src}?imgeng=${params}`
-}
-
-export function generateSrcSetString(srcSet: TSrcSet, deliveryAddress: string): string {
-  return srcSet.reduce((result, { src, width, directives }) => {
-    // Extract width directive and always apply it to the image as
-    // its size has to match provided width descriptor.
-    const widthDirective = {
-      width: Number(width.replace("w", "")),
-    }
-    const fullImageUrl = constructUrl(
-      deliveryAddress + src,
-      directives
-        ? {
-            ...directives,
-            ...widthDirective,
-          }
-        : widthDirective
-    )
-    const entry = `${fullImageUrl} ${width},\n`
-    return result += entry
-  }, "")
-}
+};


### PR DESCRIPTION
Added support for a delivery address of 'dev' that when set disabled using the directives and building distribution urls, so that it can be used locally while developing with local files

Added support to empty strings for outputFormat and fitMethod on TDirectives so that it ignores them if they're set to empty - a reason why this might happen is if you're setting those things programatically - in that same line of thought, probably all directives should allow for null/undefined