### PR TITLE
Refactor to use imageengine-helpers package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,118 @@
 {
   "name": "@imageengine/react",
   "version": "0.10.6",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@imageengine/react",
+      "version": "0.10.6",
+      "license": "MIT",
+      "dependencies": {
+        "@imageengine/imageengine-helpers": "^0.0.5"
+      },
+      "devDependencies": {
+        "@types/react": "^17.0.3",
+        "typescript": "^4.2.3"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2"
+      }
+    },
+    "node_modules/@imageengine/imageengine-helpers": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@imageengine/imageengine-helpers/-/imageengine-helpers-0.0.5.tgz",
+      "integrity": "sha512-d8X7uHkOEedPFHuxpaOmm+H9yKWHSl+5kGp+fJfcHPnnqpeh9DUTv43hKKLjzNXbu0wNkOjyUBZ6+i1rktuqpA=="
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.4.tgz",
+      "integrity": "sha512-onz2BqScSFMoTRdJUZUDD/7xrusM8hBA2Fktk2qgaTYPCgPvWnDEgkrOs8hhPUf2jfcIXkJ5yK6VfYormJS3Jw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
+    "@imageengine/imageengine-helpers": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@imageengine/imageengine-helpers/-/imageengine-helpers-0.0.5.tgz",
+      "integrity": "sha512-d8X7uHkOEedPFHuxpaOmm+H9yKWHSl+5kGp+fJfcHPnnqpeh9DUTv43hKKLjzNXbu0wNkOjyUBZ6+i1rktuqpA=="
+    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -32,6 +141,37 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
       "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true
+    },
+    "react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "typescript": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "homepage": "https://github.com/imgeng/imageengine-react#readme",
   "dependencies": {
-    "@imageengine/imageengine-helpers": "^0.0.5"
+    "@imageengine/imageengine-helpers": "^0.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imageengine/react",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "React components for seamless integration with ImageEngine",
   "main": "build/index.js",
   "scripts": {
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/imgeng/imageengine-react/issues"
   },
-  "homepage": "https://github.com/imgeng/imageengine-react#readme"
+  "homepage": "https://github.com/imgeng/imageengine-react#readme",
+  "dependencies": {
+    "@imageengine/imageengine-helpers": "^0.0.5"
+  }
 }

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -2,11 +2,12 @@ import { useImageEngineContext } from "../context"
 import { constructUrl, generateSrcSetString } from "../utils"
 import { TImageProps } from "../types"
 
-const ALLOWED_INPUT_EXTENSIONS = [
+import { IEFormat, IEFit, IEDirectives } from "@imageengine/imageengine-helpers";
+
+const ALLOWED_INPUT_EXTENSIONS: IEFormat[] = [
   "png",
   "gif",
   "jpg",
-  "jpeg",
   "bmp",
   "webp",
   "jp2",

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -8,6 +8,7 @@ const ALLOWED_INPUT_EXTENSIONS: IEFormat[] = [
   "png",
   "gif",
   "jpg",
+  "jpeg",
   "bmp",
   "webp",
   "jp2",

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, ReactNode } from "react"
 
 import { TImageEngineProvider } from '../types'
 
-export const ImageEngineContext = createContext<Omit<TImageEngineProvider, 'children'>>({ deliveryAddress: "" })
+const ImageEngineContext = createContext<Omit<TImageEngineProvider, 'children'>>({ deliveryAddress: "" })
 
 function ImageEngineProvider({ children, deliveryAddress, stripFromSrc }: TImageEngineProvider): JSX.Element {
   return (

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, ReactNode } from "react"
 
 import { TImageEngineProvider } from '../types'
 
-const ImageEngineContext = createContext<Omit<TImageEngineProvider, 'children'>>({ deliveryAddress: "" })
+export const ImageEngineContext = createContext<Omit<TImageEngineProvider, 'children'>>({ deliveryAddress: "" })
 
 function ImageEngineProvider({ children, deliveryAddress, stripFromSrc }: TImageEngineProvider): JSX.Element {
   return (
@@ -30,4 +30,4 @@ function useImageEngineContext(): Omit<TImageEngineProvider, 'children'> {
   return ctx
 }
 
-export { ImageEngineProvider, useImageEngineContext }
+export { ImageEngineProvider, useImageEngineContext, ImageEngineContext }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,55 +1,13 @@
 import { ReactElement, ReactNode } from "react"
+import { IEDirectives } from "@imageengine/imageengine-helpers";
 
 export type TSrcSet = Array<{
   // Relative path to the image.
   src: string
   // Width descriptor.
   width: string
-  directives?: TDirectives
+  directives?: IEDirectives
 }>
-
-export interface TDirectives {
-  // Define desired width.
-  width?: number
-  // Set width to auto (with fallback).
-  autoWidthWithFallback?: number
-  // Define desired height.
-  height?: number
-  // Adjust compression.
-  // Possible range: 0-100.
-  compression?: number
-  // Define desired output format.
-  outputFormat?:
-    | "png"
-    | "gif"
-    | "jpg"
-    | "bmp"
-    | "webp"
-    | "jp2"
-    | "svg"
-    | "mp4"
-    | "jxr"
-    | "avif"
-  // Define desired fit method.
-  fitMethod?: "stretch" | "box" | "letterbox" | "cropbox"
-  // Don't apply any optimizations to the origin image.
-  noOptimization?: true
-  // Adjust sharpness.
-  // Possible range: 0-100.
-  sharpness?: number
-  // Define rotation.
-  // Possible range: -360 to 360.
-  rotate?: number
-  // Use WURFL to calculate screen's width and then scale the image accordingly.
-  // Possible range: 0-100 (float).
-  scaleToScreenWidth?: number
-  // Crop the image [width, height, left, top].
-  crop?: number[]
-  // Convert the image into a data url.
-  inline?: true
-  // Keep EXIF data.
-  keepMeta?: true
-}
 
 export type TImageEngineProvider = {
   children: ReactNode
@@ -59,7 +17,7 @@ export type TImageEngineProvider = {
 
 export type TImageProps = Omit<JSX.IntrinsicElements["img"], "src" | "srcSet"> & {
   src: string
-  directives?: TDirectives
+  directives?: IEDirectives
   srcSet?: TSrcSet
 }
 
@@ -70,3 +28,5 @@ export type TSourceProps = Omit<JSX.IntrinsicElements["source"], "srcSet"> & {
 export type TPictureProps = Omit<JSX.IntrinsicElements["source"], "children"> & {
   children: [...Array<ReactElement<TSourceProps>>, ReactElement<TImageProps>]
 }
+
+export * from "@imageengine/imageengine-helpers";

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,39 +1,8 @@
-import { TDirectives, TSrcSet } from "../types"
+import { TSrcSet } from "../types"
+import { IEDirectives, build_IE_url } from "@imageengine/imageengine-helpers";
 
-const DIRECTIVE_MAPPING: { [key: string]: string } = {
-  width: "w",
-  autoWidthWithFallback: "w_auto",
-  height: "h",
-  compression: "cmpr",
-  outputFormat: "f",
-  fitMethod: "m",
-  noOptimization: "pass",
-  sharpness: "s",
-  rotate: "r",
-  scaleToScreenWidth: "pc",
-  crop: "cr",
-  inline: "in",
-  keepMeta: "meta",
-}
-
-export function constructUrl(src: string, directives: TDirectives): string {
-  const params = Object.entries(directives)
-    // Filter out null, undefined and empty string values.
-    .filter(([, value]) => value === 0 ? true : Boolean(value))
-    .reduce((result, [key, value]) => {
-      if (DIRECTIVE_MAPPING[key]) {
-        return result + `/${DIRECTIVE_MAPPING[key]}_${value}`
-      }
-
-      console.warn(
-        `Directive '${key}' isn't recognized and won't be applied to the image.`
-      )
-      return result
-    }, "")
-
-  return params === ""
-    ? src
-    : `${src}?imgeng=${params}`
+export function constructUrl(src: string, directives: IEDirectives): string {
+  return build_IE_url(string, directives, true);
 }
 
 export function generateSrcSetString(srcSet: TSrcSet, deliveryAddress: string): string {


### PR DESCRIPTION
Hi @kamermans 

I was talking with @jonarnes about updating this package to allow usage of the same directives as `imageengine-helpers`, the reason being mostly that then other packages such as the gatsby-plugin could mention this one for what it does and the props between them would match (as well as the angular one, etc), so less confusing. It also means that types and the functions to build url's and such are the same across dependents, which I think might be better?

On the helpers package I've changed the props and types to allow the camelCase keys in use here. I've also added a test for those in terms of generating the urls with the directives as they would be normally here, but here there aren't tests - there doesn't seem to be anything that would break, but if you could give it a check would be great.

Do you think we can merge this?
