### PR TITLE
Allow query strings in image URLs

### DIFF
--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -29,7 +29,7 @@ export function Image(props: TImageProps): JSX.Element {
 
   const { deliveryAddress, stripFromSrc } = useImageEngineContext()
   const imageUrl = deliveryAddress + (stripFromSrc ? src.replace(stripFromSrc, '') : src)
-  const [imageExtension] = src.split(".").slice(-1)
+  const [imageExtension] = new URL(imageUrl).pathname.split(".").slice(-1)
 
   if (!ALLOWED_INPUT_EXTENSIONS.includes(imageExtension.toLowerCase() as IEFormat)) {
     console.warn(


### PR DESCRIPTION
This PR makes it possible to use query strings in image URLs like `?v=1234` without the warning from failed `ALLOWED_INPUT_EXTENSIONS` validation.  The validation check should be checking the extension of the path, not the entire URL with the query string.